### PR TITLE
Initialization of the extension now compatible with symfony 2.1

### DIFF
--- a/DependencyInjection/VMelnikDoctrineEncryptExtension.php
+++ b/DependencyInjection/VMelnikDoctrineEncryptExtension.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\Loader;
 
 /**
  * Initializetion of bundle.
- * 
+ *
  * This is the class that loads and manages your bundle configuration
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
@@ -45,4 +45,8 @@ class VMelnikDoctrineEncryptExtension extends Extension {
         $loader->load(sprintf('%s.xml', $services[$config['db_driver']]));
     }
 
+    public function getAlias()
+    {
+        return 'vmelnik_doctrine_encrypt';
+    }
 }

--- a/VMelnikDoctrineEncryptBundle.php
+++ b/VMelnikDoctrineEncryptBundle.php
@@ -3,7 +3,13 @@
 namespace VMelnik\DoctrineEncryptBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use VMelnik\DoctrineEncryptBundle\DependencyInjection\VMelnikDoctrineEncryptExtension;
+
 
 class VMelnikDoctrineEncryptBundle extends Bundle {
-    
+    public function getContainerExtension()
+    {
+        return new VMelnikDoctrineEncryptExtension();
+    }
 }


### PR DESCRIPTION
Currently the extension is not compatible with symfony 2.1 because of the extension alias which differs from what symfony would generate based on the name of the bundle:

```
LogicException: The extension alias for the default extension of a bundle must be the underscored version of the bundle name ("v_melnik_doctrine_encrypt" instead of "vmelnik_doctrine_encrypt")
```

To be able to continue using "vmelnik_doctrine_encrypt" instead of "v_melnik_doctrine_encrypt", it is necessary to implement the getAlias()-Method of the extension. Additionally, the container extension has to be created manually instead of letting Symfony\Component\HttpKernel\Bundle\Bundle->getContainerExtension() take a guess at the extension name.

I'm not sure if this changeset breaks backwards compatibilty with symfony 2.0. Maybe you could consider creating a symfony 2.1 branch of your bundle :)

Thx
