### PR TITLE
Let the requirements of composer reflect the dependency on mcrypt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "description": "Symfony 2 bundle which allows to encrypt data in database with some encrypt algorithm",
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": ">=2.0"
+        "symfony/framework-bundle": ">=2.0",
+        "ext-mcrypt": "*"
     },
     "autoload": {
         "psr-0": { "VMelnik\\DoctrineEncryptBundle": "" }


### PR DESCRIPTION
If we add the dependency on the mcrypt extension in composers requirements, we will be notified if we try to deploy on a system where it is missing :)

thx
