### PR TITLE
Doctrine Encryption Bundle - Added postPersist and postUpdate methods…

### DIFF
--- a/Subscribers/DoctrineEncryptSubscriber.php
+++ b/Subscribers/DoctrineEncryptSubscriber.php
@@ -94,7 +94,9 @@ class DoctrineEncryptSubscriber implements EventSubscriber {
         foreach ($properties as $refProperty) {
             if ($this->annReader->getPropertyAnnotation($refProperty, self::ENCRYPTED_ANN_NAME)) {
                 $propName = $refProperty->getName();
-                $args->setNewValue($propName, $this->encryptor->encrypt($args->getNewValue($propName)));
+                if ($args->hasChangedField($propName)) {
+                    $args->setNewValue($propName, $this->encryptor->encrypt($args->getNewValue($propName)));
+                }
             }
         }
     }

--- a/Subscribers/DoctrineEncryptSubscriber.php
+++ b/Subscribers/DoctrineEncryptSubscriber.php
@@ -72,6 +72,17 @@ class DoctrineEncryptSubscriber implements EventSubscriber {
     }
 
     /**
+     * Listen a postPresist lifecycle event.
+     *
+     * @param LifecycleEventArgs $args LifecycleEventArgs
+     *
+     * @return void
+     */
+    public function postPersist(LifecycleEventArgs $args) {
+        $this->checkAndReloadEntities($args);
+    }
+
+    /**
      * Listen a preUpdate lifecycle event. Checking and encrypt entities fields
      * which have @Encrypted annotation. Using changesets to avoid preUpdate event
      * restrictions
@@ -87,13 +98,36 @@ class DoctrineEncryptSubscriber implements EventSubscriber {
             }
         }
     }
+    /**
+     * Listen a postUpdate lifecycle event.
+     *
+     * @param LifecycleEventArgs $args LifecycleEventArgs
+     *
+     * @return void
+     */
+    public function postUpdate(LifecycleEventArgs $args) {
+        $this->checkAndReloadEntities($args);
+    }
 
     /**
-     * Listen a postLoad lifecycle event. Checking and decrypt entities
-     * which have @Encrypted annotations
-     * @param LifecycleEventArgs $args 
+     * Listen a postLoad lifecycle event.
+     *
+     * @param LifecycleEventArgs $args LifecycleEventArgs
+     *
+     * @return void
      */
     public function postLoad(LifecycleEventArgs $args) {
+        $this->checkAndReloadEntities($args);
+    }
+
+    /**
+     * Checking and decrypt entities which have @Encrypted annotations
+     *
+     * @param LifecycleEventArgs $args LifecycleEventArgs
+     *
+     * @return void
+     */
+    private function checkAndReloadEntities(LifecycleEventArgs $args) {
         $entity = $args->getEntity();
         if (!$this->hasInDecodedRegistry($entity, $args->getEntityManager())) {
             if ($this->processFields($entity, false)) {
@@ -109,7 +143,9 @@ class DoctrineEncryptSubscriber implements EventSubscriber {
     public function getSubscribedEvents() {
         return array(
             Events::prePersist,
+            Events::postPersist,
             Events::preUpdate,
+            Events::postUpdate,
             Events::postLoad,
         );
     }


### PR DESCRIPTION
Added handlers to update the object in memory after persist and update operations.

Use Case:

As user, I would like to access/modify the encrypted data feidl after persistance operation like save and update. 

Commit Detail:

… to the Subscriber

(cherry picked from commit 16fb1f60f2b33879666bb57246178274b8a2905d)

Conflicts:
    Subscribers/DoctrineEncryptSubscriber.php
