### PR TITLE
Switched mcrypt to openssl

### DIFF
--- a/Encryptors/AES256Encryptor.php
+++ b/Encryptors/AES256Encryptor.php
@@ -3,11 +3,13 @@
 namespace VMelnik\DoctrineEncryptBundle\Encryptors;
 
 /**
- * Class for AES256 encryption
- * 
+ * Class for AES256 encryption.
+ *
  * @author Victor Melnik <melnikvictorl@gmail.com>
  */
-class AES256Encryptor implements EncryptorInterface {
+class AES256Encryptor implements EncryptorInterface
+{
+    const ENCRYPT_METHOD = 'aes-256-ecb';
 
     /**
      * @var string
@@ -22,37 +24,31 @@ class AES256Encryptor implements EncryptorInterface {
     /**
      * {@inheritdoc}
      */
-    public function __construct($key) {
+    public function __construct($key)
+    {
         $this->secretKey = md5($key);
-        $this->initializationVector = mcrypt_create_iv(
-            mcrypt_get_iv_size(MCRYPT_RIJNDAEL_256, MCRYPT_MODE_ECB),
-            MCRYPT_RAND
+        $this->initializationVector = openssl_random_pseudo_bytes(
+            openssl_cipher_iv_length(self::ENCRYPT_METHOD)
         );
     }
 
     /**
      * {@inheritdoc}
      */
-    public function encrypt($data) {
-        return trim(base64_encode(mcrypt_encrypt(
-            MCRYPT_RIJNDAEL_256,
-            $this->secretKey,
-            $data,
-            MCRYPT_MODE_ECB,
-            $this->initializationVector
-        )));
+    public function encrypt($data)
+    {
+        return trim(base64_encode(
+            openssl_encrypt($data, self::ENCRYPT_METHOD, $this->secretKey, 0, $this->initializationVector))
+        );
     }
 
     /**
      * {@inheritdoc}
      */
-    public function decrypt($data) {
-        return trim(mcrypt_decrypt(
-            MCRYPT_RIJNDAEL_256,
-            $this->secretKey,
-            base64_decode($data),
-            MCRYPT_MODE_ECB,
-            $this->initializationVector
-        ));
+    public function decrypt($data)
+    {
+        return trim(
+            openssl_decrypt(base64_decode($data), self::ENCRYPT_METHOD, $this->secretKey, 0, $this->initializationVector)
+        );
     }
 }

--- a/Tests/AES256EncryptorTest.php
+++ b/Tests/AES256EncryptorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace VMelnik\DoctrineEncryptBundle\Tests;
+
+use PHPUnit\Framework\TestCase;
+use VMelnik\DoctrineEncryptBundle\Encryptors\AES256Encryptor;
+
+/**
+ * Class AES256EncryptorTest.
+ */
+class AES256EncryptorTest extends TestCase
+{
+    const SECRET_KEY = '624758dbe24e20067b27fc3cef22dc61';
+
+    /**
+     * @test
+     */
+    public function checkEncryptor()
+    {
+        $aes = new AES256Encryptor(self::SECRET_KEY);
+
+        $data = 'Content some data!';
+        $encryptData = $aes->encrypt($data);
+
+        self::assertEquals($data, $aes->decrypt($encryptData));
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": ">=2.0",
-        "ext-mcrypt": "*"
+        "ext-openssl": "*"
     },
     "autoload": {
         "psr-0": { "VMelnik\\DoctrineEncryptBundle": "" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<phpunit bootstrap="./vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="The project's test suite">
+            <directory suffix=".php">./Tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
Switched mcrypt to openssl, because mcrypt has been deprecated as of PHP 7.1.0